### PR TITLE
Add Livewire widget

### DIFF
--- a/resources/views/widgets/livewire.blade.php
+++ b/resources/views/widgets/livewire.blade.php
@@ -1,0 +1,20 @@
+@php
+    // defaults; backwards compatibility with Backpack 4.0 widgets
+    $widget['wrapper']['class'] = $widget['wrapper']['class'] ?? $widget['wrapperClass'] ?? 'col-sm-6 col-lg-4';
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+
+<div class="{{ $widget['class'] ?? 'card' }}" @foreach($widget['attributes'] ?? [] as $key => $value) {{ $key }}="{{ $value }}" @endforeach>
+    @livewire($widget['component'], $widget['params'] ?? [])
+</div>
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))
+
+@pushOnce('after_styles')
+    @livewireStyles
+@endPushOnce
+
+@pushOnce('after_scripts')
+    @livewireScripts
+@endPushOnce


### PR DESCRIPTION
This adds an official Livewire widget.

## DOCUMENTATION

The following section can be added to the documentation of Widgets: 

### Livewire Widget

You can easily load a [Laravel Livewire](https://laravel-livewire.com/) component as a widget, all you have to specify is the component name and the parameters it expects. As an example, if a Livewire component is loaded regularly in this way:

```blade
<livewire:livewire-column-chart :column-chart-model="$columnChartModel" />
```

...it can be loaded in a widget using this configuration:

```php
[
   'type' => 'livewire',
   'component' => 'livewire-column-chart',
   'params' => ['columnChartModel' => $columnChartModel],
   // 'wrapper' => ['class' => 'col-md-6'], // optional
   // 'class'   => 'card bg-dark text-white', // optional
]
```

Sometimes you may need to put additional HTML attributes in the container for the component – you can just pass them to the `attributes` key as an array: 

```php
[
   'attributes' => ['rel' => 'chart', 'style' => 'height: 250px;']
]
```

## HOW TO TEST

It can be tested with any Livewire component, here I am using https://github.com/asantibanez/livewire-charts as an example.

1. Install Livewire in a project where Backpack is already configured:
    
   ```sh
   composer require livewire/livewire
   ```
2.  Install the Livewire Charts library:
    
    ```sh
    composer require asantibanez/livewire-charts
    php artisan vendor:publish --tag=livewire-charts:public
    ```
3. Create `resources/views/vendor/backpack/base/dashboard.blade.php` file with the below content:

   ```blade
   @extends(backpack_view('blank'))
   
   @php
       $pieChartModel = (new \Asantibanez\LivewireCharts\Models\PieChartModel())
           ->setTitle('Expenses by Type')
           ->addSlice('Food', 100, '#f6ad55')
           ->addSlice('Shopping', 200, '#fc8181')
           ->addSlice('Travel', 300, '#90cdf4');
   
       $widgets['before_content'][] = [
           'type' => 'livewire',
           'component' => 'livewire-pie-chart',
           'wrapper' => ['class' => 'col-md-6 col-lg-4 mt-3'],
           'params' => ['pieChartModel' => $pieChartModel],
           'attributes' => ['style' => 'height: 250px; padding-top: 20px;'],
       ];
   @endphp
   
   @push('after_scripts')
       <script src="//unpkg.com/alpinejs" defer></script>
       <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
       @livewireChartsScripts
   @endpush

   ```

4. Visiting the dashboard will now show a chart loaded through a Livewire component:

   
   ![Dashboard](https://user-images.githubusercontent.com/171715/224527419-39915911-fbb9-461a-82d5-075e7f616f16.png)
