### PR TITLE
Add tabindex to inputs

### DIFF
--- a/resources/views/auth/login/inc/form.blade.php
+++ b/resources/views/auth/login/inc/form.blade.php
@@ -3,7 +3,7 @@
     @csrf
     <div class="mb-3">
         <label class="form-label" for="{{ $username }}">{{ config('backpack.base.authentication_column_name') }}</label>
-        <input autofocus type="text" name="{{ $username }}" value="{{ old($username) }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
+        <input autofocus tabindex="1" type="text" name="{{ $username }}" value="{{ old($username) }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
         @if ($errors->has($username))
             <div class="invalid-feedback">{{ $errors->first($username) }}</div>
         @endif
@@ -17,7 +17,7 @@
                 </div>
             @endif
         </label>
-        <input type="password" name="password" id="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" value="">
+        <input tabindex="2" type="password" name="password" id="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" value="">
         @if ($errors->has('password'))
             <div class="invalid-feedback">{{ $errors->first('password') }}</div>
         @endif
@@ -29,6 +29,6 @@
         </label>
     </div>
     <div class="form-footer">
-        <button type="submit" class="btn btn-primary w-100">{{ trans('backpack::base.login') }}</button>
+        <button tabindex="3" type="submit" class="btn btn-primary w-100">{{ trans('backpack::base.login') }}</button>
     </div>
 </form>

--- a/resources/views/auth/register/inc/form.blade.php
+++ b/resources/views/auth/register/inc/form.blade.php
@@ -3,7 +3,7 @@
     @csrf
     <div class="mb-3">
         <label class="form-label" for="name">{{ trans('backpack::base.name') }}</label>
-        <input autofocus type="text" class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" name="name" id="name" value="{{ old('name') }}">
+        <input autofocus tabindex="1" type="text" class="form-control {{ $errors->has('name') ? 'is-invalid' : '' }}" name="name" id="name" value="{{ old('name') }}">
         @if ($errors->has('name'))
             <div class="invalid-feedback">{{ $errors->first('name') }}</div>
         @endif
@@ -11,7 +11,7 @@
 
     <div class="mb-3">
         <label class="form-label" for="{{ backpack_authentication_column() }}">{{ config('backpack.base.authentication_column_name') }}</label>
-        <input type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text'}}" class="form-control {{ $errors->has(backpack_authentication_column()) ? 'is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
+        <input tabindex="2" type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text'}}" class="form-control {{ $errors->has(backpack_authentication_column()) ? 'is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
         @if ($errors->has(backpack_authentication_column()))
             <div class="invalid-feedback">{{ $errors->first(backpack_authentication_column()) }}</div>
         @endif
@@ -19,7 +19,7 @@
 
     <div class="mb-3">
         <label class="form-label" for="password">{{ trans('backpack::base.password') }}</label>
-        <input type="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" name="password" id="password" value="">
+        <input tabindex="3" type="password" class="form-control {{ $errors->has('password') ? 'is-invalid' : '' }}" name="password" id="password" value="">
         @if ($errors->has('password'))
             <div class="invalid-feedback">{{ $errors->first('password') }}</div>
         @endif
@@ -27,7 +27,7 @@
 
     <div class="mb-3">
         <label class="form-label" for="password_confirmation">{{ trans('backpack::base.confirm_password') }}</label>
-        <input type="password" class="form-control {{ $errors->has('password_confirmation') ? 'is-invalid' : '' }}" name="password_confirmation" id="password_confirmation" value="">
+        <input tabindex="4" type="password" class="form-control {{ $errors->has('password_confirmation') ? 'is-invalid' : '' }}" name="password_confirmation" id="password_confirmation" value="">
         @if ($errors->has('password_confirmation'))
             <div class="invalid-feedback">{{ $errors->first('password_confirmation') }}</div>
         @endif
@@ -35,7 +35,7 @@
 
     <div class="form-group mt-3">
         <div>
-            <button type="submit" class="btn btn-primary w-100">
+            <button tabindex="5" type="submit" class="btn btn-primary w-100">
                 {{ trans('backpack::base.register') }}
             </button>
         </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Described [here](https://github.com/Laravel-Backpack/theme-tabler/issues/30).

### AFTER - What is happening after this PR?

Now you can navigate through inputs in order using tab key.


## HOW

### How did you achieve that, in technical terms?

Add tabindex to inputs.