### PR TITLE
Fix copy instruction in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ The more files you copy-paste and customize, the more difficult it will be to up
 mkdir -p resources/views/vendor/backpack/theme-tabler
 
 # copy the blade file inside the folder we created above
-cp -i vendor/backpack/theme-tabler/src/resources/views/dashboard.blade.php resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
+cp -i vendor/backpack/theme-tabler/resources/views/dashboard.blade.php resources/views/vendor/backpack/theme-tabler/dashboard.blade.php
 ```
 
 ## Change log


### PR DESCRIPTION
When trying this out, I got an error about the path. In the current repository structure, the `resources` directory is located at the root, hence this change to the `README`. 

Alternatively, the `resources` directory could be moved into `src`, but that would require other changes as well.