### PR TITLE
[Bug] Remove url helper from config

### DIFF
--- a/config/theme-tabler.php
+++ b/config/theme-tabler.php
@@ -52,11 +52,14 @@ return [
     'options' => [
         /**
          * When using horizontal_overlap layout, the overlap effect is not applied to all pages, but only a few (those that look nice).
-         * Indicate the urls that should use an overlap effect — we include the dashboard as an example.
+         * Indicate the url segments that should use an overlap effect — we include the dashboard as an example.
          * Hint: List, Create, Update operations do not look great with it, but only pages with content that can overlap the header!
+         * 
+         * We will automatically run `backpack_url('dashboard')` on the provided url segments at runtime configuration.
+         * Then we compare the current url with the generated one to decide when to use the overlap effect
          */
         'urlsUsingOverLapEffect' => [
-            url(config('backpack.base.route_prefix') . '/dashboard'),
+            'dashboard',
         ],
 
         /**

--- a/src/AddonServiceProvider.php
+++ b/src/AddonServiceProvider.php
@@ -9,7 +9,19 @@ class AddonServiceProvider extends ServiceProvider
     use AutomaticServiceProvider;
 
     protected $vendorName = 'backpack';
+
     protected $packageName = 'theme-tabler';
+
     protected $commands = [];
+
     protected $theme = true;
+
+    public function boot()
+    {
+        $this->autoboot();
+
+        $overlapEffectUrls = array_map(fn ($item) => backpack_url($item), config('backpack.theme-tabler.options.urlsUsingOverLapEffect', []));
+        
+        app('config')->set('backpack.theme-tabler.options.urlsUsingOverLapEffect', $overlapEffectUrls);
+    }
 }


### PR DESCRIPTION
Reported in https://github.com/Laravel-Backpack/theme-tabler/issues/57

TLDR: we cant use `url()` helper in the config files as it will error and break the application. 

I moved the configuration to the ServiceProvider, so instead of providing urls developer now should provide only the url segments and we generate the urls.

I still don't fully like this approach. We can't use the overlap effect in urls with dynamic segments like `user/123/profile`. 

To support that we may need to give it a little bit more thinking on how to match the urls, for now this should fix the error and keep the same behavior. 

