### PR TITLE
fix horizontal overlap layout

### DIFF
--- a/config/theme-tabler.php
+++ b/config/theme-tabler.php
@@ -51,18 +51,6 @@ return [
      */
     'options' => [
         /**
-         * When using horizontal_overlap layout, the overlap effect is not applied to all pages, but only a few (those that look nice).
-         * Indicate the url segments that should use an overlap effect — we include the dashboard as an example.
-         * Hint: List, Create, Update operations do not look great with it, but only pages with content that can overlap the header!
-         * 
-         * We will automatically run `backpack_url('dashboard')` on the provided url segments at runtime configuration.
-         * Then we compare the current url with the generated one to decide when to use the overlap effect
-         */
-        'urlsUsingOverLapEffect' => [
-            'dashboard',
-        ],
-
-        /**
          * The color mode used by default.
          */
         'defaultColorMode' => 'light', // light, dark

--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -572,15 +572,15 @@ tr.array-row td:has(span.ui-sortable-handle) {
     height: 13rem;
 }
 
-body[data-bp-layout=horizontal-overlap] .header-operation,
-body[data-bp-layout=horizontal-overlap] [bp-section=page-heading] {
+body[bp-layout=horizontal-overlap] .header-operation,
+body[bp-layout=horizontal-overlap] [bp-section=page-heading] {
     color: var(--tblr-gray-200);
 }
 
-body[data-bp-layout=horizontal-overlap] .breadcrumb .active {
+body[bp-layout=horizontal-overlap] .breadcrumb .active {
     color: var(--tblr-gray-200);
 }
 
-body[data-bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
+body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
     color: var(--tblr-gray-200);
 }

--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -561,12 +561,19 @@ tr.array-row td:has(span.ui-sortable-handle) {
     color: var(--tblr-light);
 }
 
+/* Page headers */
+
+[bp-section=page-heading] {
+    line-height: normal;
+}
+
 /* Horizontal Overlap Layout */
 .navbar-overlap:after {
     height: 13rem;
 }
 
-body[data-bp-layout=horizontal-overlap] .header-operation {
+body[data-bp-layout=horizontal-overlap] .header-operation,
+body[data-bp-layout=horizontal-overlap] [bp-section=page-heading] {
     color: var(--tblr-gray-200);
 }
 

--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -541,6 +541,7 @@ header .nav-separator {
     line-height: 27px !important;
 }
 
+
 ol li.ui-sortable-placeholder.placeholder {
     width: 100%;
     height: 35px;
@@ -558,4 +559,21 @@ tr.array-row td:has(span.ui-sortable-handle) {
 [data-bs-theme=dark] tr.array-row td button.removeItem {
     background-color: var(--tblr-gray-600);
     color: var(--tblr-light);
+}
+
+/* Horizontal Overlap Layout */
+.navbar-overlap:after {
+    height: 13rem;
+}
+
+body[data-bp-layout=horizontal-overlap] .header-operation {
+    color: var(--tblr-gray-200);
+}
+
+body[data-bp-layout=horizontal-overlap] .breadcrumb .active {
+    color: var(--tblr-gray-200);
+}
+
+body[data-bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
+    color: var(--tblr-gray-200);
 }

--- a/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
@@ -1,5 +1,5 @@
 @php
-  $shouldApplyOverlapEffect = in_array(url()->current(), backpack_theme_config('options.urlsUsingOverLapEffect') ?? []);
+  $shouldApplyOverlapEffect = backpack_theme_config('layout') == 'horizontal_overlap';
 @endphp
 
 <header class="{{ backpack_theme_config('classes.menuHorizontalContainer') ?? 'navbar-expand-lg top' }}">

--- a/resources/views/layouts/horizontal.blade.php
+++ b/resources/views/layouts/horizontal.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal.blade.php
+++ b/resources/views/layouts/horizontal.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="horizontal">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal.blade.php
+++ b/resources/views/layouts/horizontal.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_dark.blade.php
+++ b/resources/views/layouts/horizontal_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal-dark'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_dark.blade.php
+++ b/resources/views/layouts/horizontal_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal-dark">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="horizontal-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_dark.blade.php
+++ b/resources/views/layouts/horizontal_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal-dark'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_overlap.blade.php
+++ b/resources/views/layouts/horizontal_overlap.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal-overlap'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_overlap.blade.php
+++ b/resources/views/layouts/horizontal_overlap.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='horizontal-overlap'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal-overlap">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/horizontal_overlap.blade.php
+++ b/resources/views/layouts/horizontal_overlap.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="horizontal-overlap">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="horizontal-overlap">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/plain.blade.php
+++ b/resources/views/layouts/plain.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='plain'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/plain.blade.php
+++ b/resources/views/layouts/plain.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='plain'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="plain">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/plain.blade.php
+++ b/resources/views/layouts/plain.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="plain">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="plain">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical.blade.php
+++ b/resources/views/layouts/right_vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical.blade.php
+++ b/resources/views/layouts/right_vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="right-vertical">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical.blade.php
+++ b/resources/views/layouts/right_vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_dark.blade.php
+++ b/resources/views/layouts/right_vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical-dark'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_dark.blade.php
+++ b/resources/views/layouts/right_vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical-dark'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_dark.blade.php
+++ b/resources/views/layouts/right_vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical-dark">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="right-vertical-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_transparent.blade.php
+++ b/resources/views/layouts/right_vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical-transparent'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_transparent.blade.php
+++ b/resources/views/layouts/right_vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical-transparent">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="right-vertical-transparent">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/right_vertical_transparent.blade.php
+++ b/resources/views/layouts/right_vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='right-vertical-transparent'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="right-vertical-transparent">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical.blade.php
+++ b/resources/views/layouts/vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical.blade.php
+++ b/resources/views/layouts/vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="vertical">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical.blade.php
+++ b/resources/views/layouts/vertical.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_dark.blade.php
+++ b/resources/views/layouts/vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical-dark">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="vertical-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_dark.blade.php
+++ b/resources/views/layouts/vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical-dark'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical-dark">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_dark.blade.php
+++ b/resources/views/layouts/vertical_dark.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical-dark'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_transparent.blade.php
+++ b/resources/views/layouts/vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}">
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical-transparent'>
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_transparent.blade.php
+++ b/resources/views/layouts/vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical-transparent">
+<body class="{{ backpack_theme_config('classes.body') }}" bp-layout="vertical-transparent">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/resources/views/layouts/vertical_transparent.blade.php
+++ b/resources/views/layouts/vertical_transparent.blade.php
@@ -6,7 +6,7 @@
     @include(backpack_view('inc.head'))
 </head>
 
-<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout='vertical-transparent'>
+<body class="{{ backpack_theme_config('classes.body') }}" data-bp-layout="vertical-transparent">
 
 @include(backpack_view('layouts.partials.light_dark_mode_logic'))
 

--- a/src/AddonServiceProvider.php
+++ b/src/AddonServiceProvider.php
@@ -9,19 +9,7 @@ class AddonServiceProvider extends ServiceProvider
     use AutomaticServiceProvider;
 
     protected $vendorName = 'backpack';
-
     protected $packageName = 'theme-tabler';
-
     protected $commands = [];
-
     protected $theme = true;
-
-    public function boot()
-    {
-        $this->autoboot();
-
-        $overlapEffectUrls = array_map(fn ($item) => backpack_url($item), config('backpack.theme-tabler.options.urlsUsingOverLapEffect', []));
-        
-        app('config')->set('backpack.theme-tabler.options.urlsUsingOverLapEffect', $overlapEffectUrls);
-    }
 }


### PR DESCRIPTION
Fixes the issues mentioned in https://github.com/Laravel-Backpack/theme-tabler/issues/59

- adds some extra CSS, for this particular layout, that make it pretty on all CRUD pages;
- removes the `urlsUsingOverLapEffect` config;
- removes the workaround Pedro added in the ServiceProvider;

After this PR, most pages look pretty good with this layout:
![CleanShot 2023-06-13 at 08 07 01](https://github.com/Laravel-Backpack/theme-tabler/assets/1032474/09ea7560-6d67-48d3-a681-4b0df0cb12b4)

Some addons still need adjusting, though. In the process I've noticed not all pages use the same classes for the Heading. So it's impossible to style all of them using one CSS rule. We should probably use the same syntax for the Heading, across all packages and operation. That way it'll be easy to target, both for our themes and custom themes. So TODOs:

- [x] also whiten the heading on addons (LogManager, BackupManager etc)
- [x] give it another round of testing and see what else doesn't look good in this layout