### PR TITLE
remove administration keyword from menus

### DIFF
--- a/resources/views/layouts/_horizontal/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal/menu_container.blade.php
@@ -36,7 +36,6 @@
         </ul>
         <div class="collapse navbar-collapse" id="mobile-menu">
             <ul class="navbar-nav pt-lg-3">
-                <li class="px-3 fw-bold">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
                 @include(backpack_view('inc.sidebar_content'))
             </ul>
         </div>

--- a/resources/views/layouts/_horizontal_dark/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal_dark/menu_container.blade.php
@@ -36,7 +36,6 @@
         </ul>
         <div class="collapse navbar-collapse" id="mobile-menu">
             <ul class="navbar-nav pt-lg-3">
-                <li class="px-3 fw-bold">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
                 @include(backpack_view('inc.sidebar_content'))
             </ul>
         </div>

--- a/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
@@ -39,7 +39,6 @@
         </ul>
         <div class="collapse navbar-collapse" id="mobile-menu">
             <ul class="navbar-nav pt-lg-3">
-                <li class="px-3 fw-bold">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
                 @include(backpack_view('inc.sidebar_content'))
             </ul>
         </div>

--- a/resources/views/layouts/_right_vertical/menu_container.blade.php
+++ b/resources/views/layouts/_right_vertical/menu_container.blade.php
@@ -21,7 +21,7 @@
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
                     @include(backpack_view('layouts._right_vertical.sidebar_content_top'))
-                    <li class="nav-separator">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
+                    <li class="nav-separator"></li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_right_vertical_dark/menu_container.blade.php
+++ b/resources/views/layouts/_right_vertical_dark/menu_container.blade.php
@@ -21,7 +21,7 @@
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
                     @include(backpack_view('layouts._vertical.sidebar_content_top'))
-                    <li class="nav-separator">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
+                    <li class="nav-separator"></li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_right_vertical_transparent/menu_container.blade.php
+++ b/resources/views/layouts/_right_vertical_transparent/menu_container.blade.php
@@ -19,7 +19,6 @@
             </h1>
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
-                    <li class="px-3 fw-bold">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_vertical/menu_container.blade.php
+++ b/resources/views/layouts/_vertical/menu_container.blade.php
@@ -21,7 +21,7 @@
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
                     @include(backpack_view('layouts._vertical.sidebar_content_top'))
-                    <li class="nav-separator">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
+                    <li class="nav-separator"></li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_vertical_dark/menu_container.blade.php
+++ b/resources/views/layouts/_vertical_dark/menu_container.blade.php
@@ -20,7 +20,7 @@
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
                     @include(backpack_view('layouts._vertical.sidebar_content_top'))
-                    <li class="nav-separator">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
+                    <li class="nav-separator"></li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_vertical_transparent/menu_container.blade.php
+++ b/resources/views/layouts/_vertical_transparent/menu_container.blade.php
@@ -17,7 +17,6 @@
             </h1>
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
-                    <li class="px-3 fw-bold">{{ ucfirst(strtolower(trans('backpack::base.administration'))) }}</li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>


### PR DESCRIPTION
In tabler, all layouts had their sidebars start with a hardcoded "Administration" separator. That was discovered in https://github.com/Laravel-Backpack/CRUD/issues/5134 because there was no way to remove it.

This PR removes that hardcoded item. I checked all layouts, sidebar still look good without it. Even better, actually.

This PR fixes https://github.com/Laravel-Backpack/theme-tabler/issues/65