### PR TITLE
make horizontal-overlap the default layout

### DIFF
--- a/config/theme-tabler.php
+++ b/config/theme-tabler.php
@@ -22,7 +22,7 @@ return [
      * Possible values: horizontal, horizontal_dark, horizontal_overlap, vertical,
      * vertical_dark, vertical_transparent (legacy theme), right_vertical, right_vertical_dark, right_vertical_transparent
      */
-    'layout' => 'vertical_transparent',
+    'layout' => 'horizontal_overlap',
 
     /**
      * Pick a login page layout.
@@ -81,7 +81,7 @@ return [
         /**
          * When true, horizontal layouts will display the classic top bar on top to free some space when multiple nav items are used.
          */
-        'doubleTopBarInHorizontalLayouts' => true,
+        'doubleTopBarInHorizontalLayouts' => false,
     ],
 
     /**


### PR DESCRIPTION
I've wanted this ever since I've decided we use Tabler as the default theme in Backpack. But with the previous implementation... I wasn't comfortable with it, it was a bit quirky and not all default pages looked good. 

But now... NOW... I think this is the best-looking layout we have:

 

https://github.com/Laravel-Backpack/theme-tabler/assets/1032474/581f33e4-370f-4508-b154-602ab6dd0699

Add that to the fact that it's `horizontal`, which is what we want _most_ devs to use (because it makes tables much easier to use) and... yeah... it's a no-brainer 😀

If anybody thinks this was a bad idea, please tell me. If you also think this is awesome, please tell me that too 😅