### PR TITLE
add styles for DevTools

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -596,3 +596,16 @@ body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
     font-size: 85%;
     font-weight: 300;
 }
+
+
+/* devtools adjustments */
+
+[data-bs-theme="light"] [bp-section=devtools-preview-files] .nav.nav-pills {
+    background: white;
+    border-radius: 4px;
+}
+
+[data-bs-theme="light"] [bp-section=devtools-preview-files] .tab-content {
+    background: white;
+    border-radius: 4px;
+}


### PR DESCRIPTION
Added a little CSS for DevTools to look good in Tabler too, especially when using the `horizontal-overlap` layout.

![CleanShot 2023-07-01 at 12 14 38](https://github.com/Laravel-Backpack/theme-tabler/assets/1032474/b25f8079-36a7-4b30-91b3-947c98d872dc)
