### PR TITLE
Conditionally display the account and password reset links

### DIFF
--- a/resources/views/auth/login/inc/form.blade.php
+++ b/resources/views/auth/login/inc/form.blade.php
@@ -22,7 +22,7 @@
             <input tabindex="3" type="checkbox" class="form-check-input">
             <span class="form-check-label">{{ trans('backpack::base.remember_me') }}</span>
         </label>
-        @if (backpack_users_have_email())
+        @if (backpack_users_have_email() && backpack_email_column() == 'email' && config('backpack.base.setup_password_recovery_routes', true))
             <div class="form-label-description">
                 <a tabindex="4" href="{{ route('backpack.auth.password.reset') }}">{{ trans('backpack::base.forgot_your_password') }}</a>
             </div>

--- a/resources/views/inc/menu_user_dropdown.blade.php
+++ b/resources/views/inc/menu_user_dropdown.blade.php
@@ -14,8 +14,10 @@
         </div>
     </a>
     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
-        <a href="{{ route('backpack.account.info') }}" class="dropdown-item"><i class="la la-user me-2"></i>{{ trans('backpack::base.my_account') }}</a>
-        <div class="dropdown-divider"></div>
+        @if(config('backpack.base.setup_my_account_routes'))
+            <a href="{{ route('backpack.account.info') }}" class="dropdown-item"><i class="la la-user me-2"></i>{{ trans('backpack::base.my_account') }}</a>
+            <div class="dropdown-divider"></div>
+        @endif
         <a href="{{ backpack_url('logout') }}" class="dropdown-item"><i class="la la-lock me-2"></i>{{ trans('backpack::base.logout') }}</a>
     </div>
 </div>

--- a/resources/views/layouts/_vertical/sidebar_content_top.blade.php
+++ b/resources/views/layouts/_vertical/sidebar_content_top.blade.php
@@ -19,10 +19,12 @@
                 {{ backpack_user()->name }}
             </a>
             <div class="dropdown-menu" data-bs-popper="static">
-                <a class="dropdown-item" href="{{ route('backpack.account.info') }}">
-                    <i class="nav-icon la la-lock d-block"></i>
-                    {{ trans('backpack::base.my_account') }}
-                </a>
+                @if(config('backpack.base.setup_my_account_routes'))
+                    <a class="dropdown-item" href="{{ route('backpack.account.info') }}">
+                        <i class="nav-icon la la-lock d-block"></i>
+                        {{ trans('backpack::base.my_account') }}
+                    </a>
+                @endif
                 <a class="dropdown-item text-danger" href="{{ backpack_url('logout') }}">
                     <i class="nav-icon la la-sign-out-alt d-block"></i>
                     {{ trans('backpack::base.logout') }}


### PR DESCRIPTION
reported in https://github.com/Laravel-Backpack/CRUD/issues/5188

Some routes may not be available if you disable certain options in config like `setup_my_account_routes` and `setup_password_recovery_routes`.

If not checked the would throw errors that the route is not defined.

