### PR TITLE
ColorMode event return the actual color

### DIFF
--- a/resources/views/layouts/partials/light_dark_mode_logic.blade.php
+++ b/resources/views/layouts/partials/light_dark_mode_logic.blade.php
@@ -36,11 +36,15 @@
             document.documentElement.dataset.bsTheme = theme;
             document.body.classList.add(`theme-${theme}`);
 
-            this.listeners.forEach(listener => listener && listener(this.value));
+            this.listeners.forEach(listener => listener && listener(this.result));
         }
 
         get() {
             return this.value;
+        }
+
+        get result() {
+            return this.value === 'system' ? this.valueSystem : this.value;
         }
 
         onColorSchemeChange(query) {


### PR DESCRIPTION
Previously it was returning the user selected color scheme, instead of the actual color scheme, resulting form combining user selection and system scheme.

Will be helpful in situations like this one; https://github.com/Laravel-Backpack/PRO/pull/182/files#diff-18db4ee97b3548317fccfa09f53d68fb1849fcc79d0c4687181b3025cb1c8acdR97