### PR TITLE
Multiple menu items get selected if another slug has substring.

### DIFF
--- a/resources/assets/js/tabler.js
+++ b/resources/assets/js/tabler.js
@@ -4,7 +4,7 @@ document.querySelectorAll('aside a.nav-link.dropdown-toggle').forEach(el => el.d
 
 // Bar layout - Highlight active section/page
 [...document.querySelectorAll('aside a[href], header.top a[href]')]
-    .filter(el => window.location.href.startsWith(el.href) && !el.href.endsWith('#'))
+    .filter(el => window.location.href.split("#")[0].split("?")[0] === el.href)
     .forEach(el => {
         while (/(nav-item|nav-link|dropdown)/.test(el.className)) {
             if (el.previousElementSibling?.dataset.bsAutoClose === 'false') el.classList.add('show');


### PR DESCRIPTION
Solves https://github.com/Laravel-Backpack/CRUD/issues/5114

### Problem
Multiple menu items get selected if they have the same prefix or substring.
Let's enhance the logic which adds an `active` class more precisely.
#### More info and users feedback here: https://github.com/Laravel-Backpack/community-forum/discussions/523
![](https://user-images.githubusercontent.com/34405837/243910224-be3cbab9-c60c-4fb7-8109-73ef454282b4.png)


**Tested on all themes:**
- CoreUI-V2✅(Works)
- CoreUI-V4✅(Works)
- Tabler❌(This theme has this issue)
