### PR TITLE
Fixing project logo to link to home_link

### DIFF
--- a/resources/views/layouts/_horizontal/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal/menu_container.blade.php
@@ -5,7 +5,7 @@
                 <ul class="navbar-nav">
                     @unless(backpack_theme_config('options.doubleTopBarInHorizontalLayouts'))
                         <li class="nav-brand">
-                            <a class="nav-link" href="{{ backpack_url('dashboard') }}">
+                            <a class="nav-link" href="{{ url(backpack_theme_config('home_link')) }}">
                                 {!! backpack_theme_config('project_logo') !!}
                             </a>
                         </li>


### PR DESCRIPTION
Horizontal layout doesn't incorporate the home_link properly in the logo. I've fixed that.