### PR TITLE
move colorMode from constant to window object

### DIFF
--- a/resources/views/layouts/partials/light_dark_mode_logic.blade.php
+++ b/resources/views/layouts/partials/light_dark_mode_logic.blade.php
@@ -68,7 +68,7 @@
         }
     }
 
-    const colorMode = new ColorMode(
+    window.colorMode = new ColorMode(
         // color modes list
         @json(array_keys(backpack_theme_config('options.colorModes') ?? [])),
 


### PR DESCRIPTION
Jorge is having issues accessing colorMode in elfinder views. 
That's because they render in separate iframes outside of the colorMode constant scope.

Adding the colorMode to the window object would allow us to access it with `window.parent` on elfinder iframe. 

AFAIK there is no other implications apart from making it globally available. 

