### PR TITLE
fix white flick when in dark mode

### DIFF
--- a/resources/views/inc/theme_styles.blade.php
+++ b/resources/views/inc/theme_styles.blade.php
@@ -1,2 +1,8 @@
+{{-- 
+    we use a render blocking script in <head> to force the theme attribute to be in the document before it renders 
+    avoiding white flicks when for example, using the dark color mode.
+--}}
+<script>document.documentElement.setAttribute("data-bs-theme", localStorage.colorMode ?? 'light');</script>
+
 @basset('https://unpkg.com/@tabler/core@1.0.0-beta19/dist/css/tabler.min.css')
 @basset(base_path('vendor/backpack/theme-tabler/resources/assets/css/style.css'))


### PR DESCRIPTION
this fixes #121 

This script is called a "render blocking" script, because it's placed in the head and will be evaluated before the page renders. 
It's so fast that it don't add any overhead, and avoid the white flick. 

