### PR TITLE
Progress widgets text color fix

### DIFF
--- a/resources/views/widgets/progress.blade.php
+++ b/resources/views/widgets/progress.blade.php
@@ -19,7 +19,7 @@
 
     <div class="card-body">
         @if (isset($widget['description']))
-            <div class="@if(($widget['ribbon'][0] ?? '') === 'bottom') pe-3 @endif">{!! $widget['description'] !!}</div>
+            <div class="card-title @if(($widget['ribbon'][0] ?? '') === 'bottom') pe-3 @endif">{!! $widget['description'] !!}</div>
         @endif
 
         @if (isset($widget['value']))

--- a/resources/views/widgets/progress.blade.php
+++ b/resources/views/widgets/progress.blade.php
@@ -19,7 +19,7 @@
 
     <div class="card-body">
         @if (isset($widget['description']))
-            <div class="subheader @if(($widget['ribbon'][0] ?? '') === 'bottom') pe-3 @endif">{!! $widget['description'] !!}</div>
+            <div class="@if(($widget['ribbon'][0] ?? '') === 'bottom') pe-3 @endif">{!! $widget['description'] !!}</div>
         @endif
 
         @if (isset($widget['value']))

--- a/resources/views/widgets/progress_white.blade.php
+++ b/resources/views/widgets/progress_white.blade.php
@@ -13,15 +13,15 @@
       @if (isset($widget['description']))
       <div>{!! $widget['description'] !!}</div>
       @endif
-      
+
       @if (isset($widget['progress']))
       <div class="progress progress-xs my-2">
         <div class="{{ $widget['progressClass'] ?? 'progress-bar bg-info' }}" role="progressbar" style="width: {{ $widget['progress']  }}%" aria-valuenow="{{ $widget['progress']  }}" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
       @endif
-      
+
       @if (isset($widget['hint']))
-      <small class="text-muted">{!! $widget['hint'] !!}</small>
+      <small>{!! $widget['hint'] !!}</small>
       @endif
     </div>
 

--- a/resources/views/widgets/progress_white.blade.php
+++ b/resources/views/widgets/progress_white.blade.php
@@ -7,7 +7,7 @@
   <div class="{{ $widget['class'] ?? 'card' }}">
     <div class="card-body">
       @if (isset($widget['value']))
-      <div class="text-value">{!! $widget['value'] !!}</div>
+      <div class="text-value"><strong>{!! $widget['value'] !!}</strong></div>
       @endif
 
       @if (isset($widget['description']))


### PR DESCRIPTION
Solves #132 
## Before
`text-white` was not applied to the description while using the `progress` widget.

![Screenshot 2023-08-11 at 1 23 04 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/a15c9c90-96c7-4a47-be7c-63f7e50a67e1)


and when I used the `progress_white` widget the output was:

![Screenshot 2023-08-11 at 1 23 19 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/4f1f0fb3-5014-47ff-bd9c-38cd6d692e0a)
## After
**Tested with & without `text-white bg-primary`. Now works both ways ✅**

![Screenshot 2023-08-11 at 5 28 22 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/185a3efb-d635-4476-9523-738edcf6ee50)


![Screenshot 2023-08-11 at 5 29 06 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/f2379eca-7a9c-4d58-b6ac-10efbc1bde01)

**Perfectly works in dark mode too** 

![Screenshot 2023-08-11 at 5 30 25 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/5408b608-0ef9-47be-bdaa-9e14da50077c)


![Screenshot 2023-08-11 at 5 32 43 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/6276c086-065f-4ce9-90c5-41aff7c09234)
