### PR TITLE
Horizontal layout tab title hard to read

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -655,6 +655,18 @@ body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
     color: var(--tblr-gray-200);
 }
 
+body[bp-layout=horizontal-overlap] .nav-item > a {
+    color: var(--tblr-gray-400);
+}
+
+[data-bs-theme=dark] body[bp-layout=horizontal-overlap] .nav-item > a {
+    color: var(--tblr-gray-500);
+}
+
+[data-bs-theme=dark] body[bp-layout=horizontal-overlap] .nav-item > a.active {
+    color: var(--tblr-gray-100);
+}
+
 /* avatar fallback */
 .backpack-avatar-menu-container {
     position: absolute;
@@ -921,7 +933,7 @@ body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
 
 [data-bs-theme=dark] #colorbox {
     background: transparent !important;
-
+}
 /* Range */
 [data-bs-theme=dark] .form-range {
     border: solid 1px var(--tblr-primary-border-subtle); /* To make more contrast could use --tblr-tabler */


### PR DESCRIPTION
Solves #130 
### Before:

In horizontal-overlap layout, the tabs titles are hard to read:

![image](https://github.com/Laravel-Backpack/theme-tabler/assets/7188159/23f22943-3a1d-4c66-b703-b69bf90e95a6)

### After:
**Light-mode**

![Screenshot 2023-08-11 at 7 36 13 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/056ec4bf-5a5a-46bc-9be3-a36995ac7aca)

**Dark-mode**

![Screenshot 2023-08-11 at 7 36 19 PM](https://github.com/Laravel-Backpack/theme-tabler/assets/8214221/b87be040-6860-45ec-a541-085e5a629c0f)
