### PR TITLE
Added missing attribute name to remember input on login form

### DIFF
--- a/resources/views/auth/login/inc/form.blade.php
+++ b/resources/views/auth/login/inc/form.blade.php
@@ -19,7 +19,7 @@
     </div>
     <div class="d-flex justify-content-between align-items-center mb-2">
         <label class="form-check mb-0">
-            <input tabindex="3" type="checkbox" class="form-check-input">
+            <input name="remember" tabindex="3" type="checkbox" class="form-check-input">
             <span class="form-check-label">{{ trans('backpack::base.remember_me') }}</span>
         </label>
         @if (backpack_users_have_email() && backpack_email_column() == 'email' && config('backpack.base.setup_password_recovery_routes', true))


### PR DESCRIPTION
Reported by @smart4you at https://github.com/Laravel-Backpack/community-forum/issues/629.

Remember input was missing it's name, so it was never being assigned.
This PR fixes that 👌