### PR TITLE
Moved all translations to `backpack::base`

### DIFF
--- a/resources/views/auth/login/inc/form.blade.php
+++ b/resources/views/auth/login/inc/form.blade.php
@@ -2,7 +2,7 @@
 <form method="POST" action="{{ route('backpack.auth.login') }}" autocomplete="off" novalidate="">
     @csrf
     <div class="mb-3">
-        <label class="form-label" for="{{ $username }}">{{ trans('backpack::base.'.config('backpack.base.authentication_column_name')) }}</label>
+        <label class="form-label" for="{{ $username }}">{{ trans('backpack::base.'.strtolower(config('backpack.base.authentication_column_name'))) }}</label>
         <input autofocus tabindex="1" type="text" name="{{ $username }}" value="{{ old($username) }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
         @if ($errors->has($username))
             <div class="invalid-feedback">{{ $errors->first($username) }}</div>

--- a/resources/views/auth/login/inc/form.blade.php
+++ b/resources/views/auth/login/inc/form.blade.php
@@ -2,7 +2,7 @@
 <form method="POST" action="{{ route('backpack.auth.login') }}" autocomplete="off" novalidate="">
     @csrf
     <div class="mb-3">
-        <label class="form-label" for="{{ $username }}">{{ trans(config('backpack.base.authentication_column_name')) }}</label>
+        <label class="form-label" for="{{ $username }}">{{ trans('backpack::base.'.config('backpack.base.authentication_column_name')) }}</label>
         <input autofocus tabindex="1" type="text" name="{{ $username }}" value="{{ old($username) }}" id="{{ $username }}" class="form-control {{ $errors->has($username) ? 'is-invalid' : '' }}">
         @if ($errors->has($username))
             <div class="invalid-feedback">{{ $errors->first($username) }}</div>

--- a/resources/views/auth/register/inc/form.blade.php
+++ b/resources/views/auth/register/inc/form.blade.php
@@ -10,7 +10,7 @@
     </div>
 
     <div class="mb-3">
-        <label class="form-label" for="{{ backpack_authentication_column() }}">{{ trans(config('backpack.base.authentication_column_name')) }}</label>
+        <label class="form-label" for="{{ backpack_authentication_column() }}">{{ trans('backpack::base.'.config('backpack.base.authentication_column_name')) }}</label>
         <input tabindex="2" type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text'}}" class="form-control {{ $errors->has(backpack_authentication_column()) ? 'is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
         @if ($errors->has(backpack_authentication_column()))
             <div class="invalid-feedback">{{ $errors->first(backpack_authentication_column()) }}</div>

--- a/resources/views/auth/register/inc/form.blade.php
+++ b/resources/views/auth/register/inc/form.blade.php
@@ -10,7 +10,7 @@
     </div>
 
     <div class="mb-3">
-        <label class="form-label" for="{{ backpack_authentication_column() }}">{{ trans('backpack::base.'.config('backpack.base.authentication_column_name')) }}</label>
+        <label class="form-label" for="{{ backpack_authentication_column() }}">{{ trans('backpack::base.'.strtolower(config('backpack.base.authentication_column_name'))) }}</label>
         <input tabindex="2" type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text'}}" class="form-control {{ $errors->has(backpack_authentication_column()) ? 'is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
         @if ($errors->has(backpack_authentication_column()))
             <div class="invalid-feedback">{{ $errors->first(backpack_authentication_column()) }}</div>

--- a/resources/views/my_account.blade.php
+++ b/resources/views/my_account.blade.php
@@ -72,7 +72,7 @@
 
                             <div class="col-md-6 form-group">
                                 @php
-                                    $label = trans('backpack::base.'.config('backpack.base.authentication_column_name'));
+                                    $label = trans('backpack::base.'.strtolower(config('backpack.base.authentication_column_name')));
                                     $field = backpack_authentication_column();
                                 @endphp
                                 <label class="required">{{ $label }}</label>

--- a/resources/views/my_account.blade.php
+++ b/resources/views/my_account.blade.php
@@ -72,7 +72,7 @@
 
                             <div class="col-md-6 form-group">
                                 @php
-                                    $label = config('backpack.base.authentication_column_name');
+                                    $label = trans('backpack::base.'.config('backpack.base.authentication_column_name'));
                                     $field = backpack_authentication_column();
                                 @endphp
                                 <label class="required">{{ $label }}</label>


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/theme-tabler/issues/107.

This will use either `email` or `username`, so it depends on https://github.com/Laravel-Backpack/CRUD/pull/5313.

This will cover 99.9% of cases, if a developer is going to use another table name he will need to add it to `/lang/vendor/backpack/en/base.php`.