### PR TITLE
Avoid unused separator

### DIFF
--- a/resources/views/layouts/_vertical/menu_container.blade.php
+++ b/resources/views/layouts/_vertical/menu_container.blade.php
@@ -21,7 +21,6 @@
             <div class="collapse navbar-collapse" id="mobile-menu">
                 <ul class="navbar-nav pt-lg-3">
                     @include(backpack_view('layouts._vertical.sidebar_content_top'))
-                    <li class="nav-separator"></li>
                     @include(backpack_view('inc.sidebar_content'))
                 </ul>
             </div>

--- a/resources/views/layouts/_vertical/sidebar_content_top.blade.php
+++ b/resources/views/layouts/_vertical/sidebar_content_top.blade.php
@@ -32,6 +32,7 @@
             </div>
         </li>
     @endif
+    <li class="nav-separator"></li>
 @endif
 
 {{--


### PR DESCRIPTION
There's an unnecessary separator on vertical layouts.
I assume it's there to create a separation between the `menu_container` and the `sidebar_content_top`, BUT, it should only by there in case there is content on `sidebar_content_top`. So I moved it there.

![image](https://github.com/Laravel-Backpack/theme-tabler/assets/1838187/de7520a7-0f95-4ac7-8f4e-3f6247ffe8b0)
