### PR TITLE
Horizontal Overlay style issue fixed

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -668,7 +668,11 @@ tr.array-row td:has(span.ui-sortable-handle) {
 }
 
 body[bp-layout=horizontal-overlap] .breadcrumb .active {
-    color: var(--tblr-gray-200);
+    color: var(--tblr-gray-700);
+}
+
+[data-bs-theme=dark] body[bp-layout=horizontal-overlap] .breadcrumb .active {
+    color: var(--tblr-gray-300);
 }
 
 body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
@@ -676,11 +680,11 @@ body[bp-layout=horizontal-overlap] .navbar-filters .navbar-nav .nav-link {
 }
 
 body[bp-layout=horizontal-overlap] .nav-item > a {
-    color: var(--tblr-gray-400);
+    color: var(--tblr-gray-800);
 }
 
 [data-bs-theme=dark] body[bp-layout=horizontal-overlap] .nav-item > a {
-    color: var(--tblr-gray-500);
+    color: var(--tblr-gray-300);
 }
 
 [data-bs-theme=dark] body[bp-layout=horizontal-overlap] .nav-item > a.active {

--- a/resources/views/layouts/_horizontal/header_container.blade.php
+++ b/resources/views/layouts/_horizontal/header_container.blade.php
@@ -1,4 +1,4 @@
-<header data-bs-theme={{ $theme ?? 'system' }} class="d-print-none {{ backpack_theme_config('classes.topHeader') ?? 'd-none d-lg-block px-3 navbar navbar-expand-md navbar-'.($theme ?? 'light') }}">
+<header data-bs-theme="{{ $theme ?? 'system' }}" class="d-print-none {{ backpack_theme_config('classes.topHeader') ?? 'd-none d-lg-block px-3 navbar navbar-expand-md navbar-'.($theme ?? 'light') }}">
     <div class="{{ backpack_theme_config('options.useFluidContainers') ? 'container-fluid' : 'container-xl' }}">
         <div class="{{ backpack_theme_config('options.useFluidContainers') ? 'container-fluid' : 'container-xl' }} d-flex align-items-center justify-content-between">
             <a class="h2 text-decoration-none mb-0" href="{{ url(backpack_theme_config('home_link')) }}" title="{{ backpack_theme_config('project_name') }}">

--- a/resources/views/layouts/_horizontal/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal/menu_container.blade.php
@@ -1,4 +1,4 @@
-<header data-bs-theme={{ $theme ?? 'system' }} class="{{ backpack_theme_config('classes.menuHorizontalContainer') ?? 'navbar-expand-lg top' }}">
+<header data-bs-theme="{{ $theme ?? 'system' }}" class="{{ backpack_theme_config('classes.menuHorizontalContainer') ?? 'navbar-expand-lg top' }}">
     <div class="collapse navbar-collapse" id="navbar-menu">
         <div class="d-print-none {{ backpack_theme_config('classes.menuHorizontalContent') ?? 'navbar navbar-expand-lg navbar-'.($theme ?? 'light').' navbar-'.(($overlap ?? false) ? 'overlap' : '') }}">
             <div class="{{ backpack_theme_config('options.useFluidContainers') ? 'container-fluid' : 'container-xl' }}">
@@ -21,7 +21,7 @@
 </header>
 
 {{-- we use this here to display the mobile menu --}}
-<aside data-bs-theme={{ $theme ?? 'system' }} class="navbar navbar-expand-lg navbar-{{ $theme ?? 'light' }} d-block d-lg-none">
+<aside data-bs-theme="{{ $theme ?? 'system' }}" class="navbar navbar-expand-lg navbar-{{ $theme ?? 'light' }} d-block d-lg-none">
     <div class="container-fluid">
         <ul class="nav navbar-nav d-flex flex-row align-items-center justify-content-between w-100">
             @include(backpack_view('layouts.partials.mobile_toggle_btn'), ['forceWhiteLabelText' => true])

--- a/resources/views/layouts/_horizontal_overlap/header_container.blade.php
+++ b/resources/views/layouts/_horizontal_overlap/header_container.blade.php
@@ -1,3 +1,1 @@
-@extends(backpack_view('layouts._horizontal.header_container'), [
-    'theme' => 'dark',
-])
+@extends(backpack_view('layouts._horizontal.header_container'))

--- a/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
+++ b/resources/views/layouts/_horizontal_overlap/menu_container.blade.php
@@ -1,4 +1,3 @@
 @extends(backpack_view('layouts._horizontal.menu_container'), [
-    'theme' => 'dark',
     'overlap' => true,
 ])

--- a/resources/views/layouts/_vertical/menu_container.blade.php
+++ b/resources/views/layouts/_vertical/menu_container.blade.php
@@ -1,5 +1,5 @@
 @if (backpack_auth()->check())
-    <aside data-bs-theme={{ $theme ?? 'system' }} class="{{ backpack_theme_config('classes.sidebar') ?? 'navbar navbar-vertical '.(($right ?? false) ? 'navbar-right' : '').' navbar-expand-lg navbar-'.($theme ?? 'light') }} @if(backpack_theme_config('options.sidebarFixed')) navbar-fixed @endif">
+    <aside data-bs-theme="{{ $theme ?? 'system' }}" class="{{ backpack_theme_config('classes.sidebar') ?? 'navbar navbar-vertical '.(($right ?? false) ? 'navbar-right' : '').' navbar-expand-lg navbar-'.($theme ?? 'light') }} @if(backpack_theme_config('options.sidebarFixed')) navbar-fixed @endif">
         <div class="container-fluid">
             <ul class="nav navbar-nav d-flex flex-row align-items-center justify-content-between w-100 d-block d-lg-none">
                 @include(backpack_view('layouts.partials.mobile_toggle_btn'), ['forceWhiteLabelText' => true])


### PR DESCRIPTION
For the Horizontal overlay style dark mode and light mode style look the same. IMHO it would reflect the mode setting, not the theme example. for that I made these changes please review.
![bg 2023-10-22_15-58](https://github.com/Laravel-Backpack/theme-tabler/assets/24684511/1c223da5-8bc8-40da-9127-ff88ed597bdb)
![bp light](https://github.com/Laravel-Backpack/theme-tabler/assets/24684511/f5c5999f-2522-4bde-9
My Suggestion PR
![sol1](https://github.com/Laravel-Backpack/theme-tabler/assets/24684511/e8d178bc-28ea-445d-bf82-95321912a526)
![sol2](https://github.com/Laravel-Backpack/theme-tabler/assets/24684511/82ea29f0-38a5-4efa-b828-b4b119c72d5b)
