### PR TITLE
Fix horizontal_overlap in light mode

### DIFF
--- a/resources/assets/css/color-adjustments.css
+++ b/resources/assets/css/color-adjustments.css
@@ -199,3 +199,7 @@
 [data-bs-theme=dark] span.input-group-text {
     border-color: var(--tblr-primary-border-subtle);
 }
+
+[data-bs-theme=light] [bp-layout=horizontal-overlap] .page-body {
+    color: var(--tblr-gray-400);
+}


### PR DESCRIPTION
As reported in this issue https://github.com/Laravel-Backpack/theme-tabler/issues/178 we have a problem with horizontal_overlap in light mode.

<img width="1166" alt="Screenshot 2024-04-23 at 12 34 49 AM" src="https://github.com/Laravel-Backpack/theme-tabler/assets/44643608/860c9565-71bf-46e7-8abc-9cdd4663b07f">

Now is fixed.