### PR TITLE
fix alerts backgrounds

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -999,5 +999,5 @@ body[bp-layout=horizontal-overlap] .nav-item > a {
 }
 
 [data-bs-theme=dark] .alert {
-    color: var(--tblr-gray-400) !important;
+    color: var(--tblr-gray-400);
 }

--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -993,3 +993,11 @@ body[bp-layout=horizontal-overlap] .nav-item > a {
 .card-body .subheader {
     color: inherit;
 }
+
+.alert {
+    background: var(--tblr-surface);
+}
+
+[data-bs-theme=dark] .alert {
+    color: var(--tblr-gray-400) !important;
+}


### PR DESCRIPTION
While working on other topic I stumbled upon this error. 

The alerts background is a fixed "#FFF" color. I went to the online demo and there it worked perfectly. 
I dig up a big more and found out it was fixed in beta20 (we use beta19 tho). 

![tabler10-20](https://github.com/Laravel-Backpack/theme-tabler/assets/7188159/fe94f81b-b192-499c-8f65-f7e826ae7763)

I didn't try to update to beta20, I just added the same fix they did, by using a `var()` from the color pallet. 

When updating to tabler20 or the 1.0.0 release we should probably remove this. 