### PR TITLE
Fix links with filters not marked as active in the menu

### DIFF
--- a/resources/assets/js/tabler.js
+++ b/resources/assets/js/tabler.js
@@ -1,6 +1,6 @@
 // Bar layout - Highlight active section/page
 [...document.querySelectorAll('aside a[href], header.top a[href]')]
-    .filter(el => window.location.href.split("#")[0].split("?")[0] === el.href)
+    .filter(el => window.location.href.split("#")[0] === el.href)
     .forEach(el => {
         while (/(nav-item|nav-link|dropdown)/.test(el.className)) {
             let parentContainer = el.parentElement?.parentElement;


### PR DESCRIPTION
Hi,

I have some links in the menu with filters applied, the problem is that they don't appear as active in the menu when you click on these links.
This pull requesut would solve the issue.

Thanks!