### PR TITLE
remove navbar box shadow override

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -52,7 +52,7 @@ a.btn.btn-sm.btn-secondary.bulk-button i {
     margin-right: 3px;
 }
 
-.navbar,
+
 .btn.btn-light.btn-sm.border.popup_selector,
 .btn.btn-light.btn-sm.border.clear_elfinder_picker {
     box-shadow: none;


### PR DESCRIPTION
This PR does one thing - remove the CSS that made all navbars NOT have box shadow. Git Blame tells us that rule was introduced by @promatik last year in https://github.com/Laravel-Backpack/theme-tabler/blame/273799115186be32da13df60bf3b06e70372f367/resources/assets/css/style.css#L55 

I really tried to find a usefulness for it, but I haven't. I checked all layouts, I checked everywhere we use a navbar... didn't find any place where this would be useful. Same, after removing it I've checked all places, everything looks better now.

For reference here's the problem it DOES fix, where I discovered it. To the left it's how it looks before this PR, to the right how it looks after:
![CleanShot 2024-08-22 at 17 42 12@2x](https://github.com/user-attachments/assets/c56b5705-7bf5-4d46-afbb-7fd4cc049e7d)

I really think this override was made in error. Or that the UI problem it was fixing no longer exists. 

It's WAAAAY to broad of a selector anyway. Saying `.navbar` should never have a box-shadow is too broad. So if this triggers a problem and I didn't see it, we should fix it with a more specific selector.