### PR TITLE
Update tabler version

### DIFF
--- a/resources/views/inc/theme_scripts.blade.php
+++ b/resources/views/inc/theme_scripts.blade.php
@@ -1,2 +1,2 @@
 @basset(base_path('vendor/backpack/theme-tabler/resources/assets/js/tabler.js'))
-@basset('https://unpkg.com/@tabler/core@1.0.0-beta19/dist/js/tabler.min.js')
+@basset('https://unpkg.com/@tabler/core@1.0.0-beta21/dist/js/tabler.min.js')

--- a/resources/views/inc/theme_styles.blade.php
+++ b/resources/views/inc/theme_styles.blade.php
@@ -4,5 +4,5 @@
 --}}
 <script>document.documentElement.setAttribute("data-bs-theme", localStorage.colorMode ?? 'light');</script>
 
-@basset('https://unpkg.com/@tabler/core@1.0.0-beta19/dist/css/tabler.min.css')
+@basset('https://unpkg.com/@tabler/core@1.0.0-beta21/dist/css/tabler.min.css')
 @basset(base_path('vendor/backpack/theme-tabler/resources/assets/css/style.css'))


### PR DESCRIPTION
We are lagging almost 2 years of tabler updates. 

Some stuff listed in their demo wouldn't work on our installation. (they released a new version about 2 months ago, `beta21`. We were still on `beta19`. 

I don't see any BC's, care to give it a second look ? 