### PR TITLE
fix switch alignment

### DIFF
--- a/resources/assets/css/style.css
+++ b/resources/assets/css/style.css
@@ -1043,3 +1043,7 @@ body[bp-layout=horizontal-overlap] .nav-item > a {
     width:3.5em;
     height: 1.8em;
 }
+
+label.switch-label {
+    padding-top: 0.1em;
+}


### PR DESCRIPTION
Fixes the switch alignment with the label.

Before:
![image](https://github.com/user-attachments/assets/c3035fc3-0621-4349-9d82-d9201613a8a7)

After:
![image](https://github.com/user-attachments/assets/59952474-4936-4639-8a73-8a0cf9d978e4)
