### PR TITLE
Make tabler backward compatible

### DIFF
--- a/resources/assets/js/tabler.js
+++ b/resources/assets/js/tabler.js
@@ -18,3 +18,8 @@
             el = el.parentElement;
         }
     });
+/**
+ * For backward compatibility with previous tabler version and other themes.
+ * In Tabler v1x, the bootstrap object is no longer available globally
+ */
+window.bootstrap = tabler.bootstrap;

--- a/resources/views/inc/theme_scripts.blade.php
+++ b/resources/views/inc/theme_scripts.blade.php
@@ -1,2 +1,2 @@
-@basset(base_path('vendor/backpack/theme-tabler/resources/assets/js/tabler.js'))
 @basset('bp-tabler-js')
+@basset(base_path('vendor/backpack/theme-tabler/resources/assets/js/tabler.js'))


### PR DESCRIPTION
after the launch of tabler v1, there is no more bootstrap object on the global window, instead it was moved to `tabler.bootstrap`. 

Since some of our code relied on `bootstrap` beeing available in global window, I've manually copied the tabler.bootstrap into `window.bootstrap`. 